### PR TITLE
add jquery/jsdom test

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "vtree-select": "https://github.com/featurist/vtree-select.git#vdom2"
   },
   "dependencies": {
+    "jsdom": "^3.1.2",
     "vtree-select": "git+https://github.com/featurist/vtree-select.git#vdom2"
   }
 }

--- a/test/jqueryTest.js
+++ b/test/jqueryTest.js
@@ -1,0 +1,35 @@
+var v$ = require('../');
+var jquery = require('jquery');
+var chai = require('chai');
+var h = require('virtual-dom/h');
+
+var html = '<a><b><c x="1"><d x="1" /></c><e /></b></a>';
+var vdom = h('a', h('b', h('c', { x: '1' }, h('d', { x: '1' })), h('e')));
+var $ = jquery(require("jsdom").jsdom().parentWindow);
+
+describe("like jQuery, $('" + html + "')", function() {
+  expect('.find("a").length', 0);
+  expect('.find("b").length', 1);
+  expect('.find("a, b").length', 1);
+  expect('.find("a b c").length', 0);
+  expect('.find("b c > d").length', 1);
+});
+
+function expect(expression, expected) {
+  it(expression + ' returns ' + expected, function() {
+    expectLibraryResult("jQuery", '$(html)' + expression, expected);
+    expectLibraryResult("vdomQuery", 'v$(vdom)' + expression, expected);
+  });
+}
+
+function expectLibraryResult(library, expression, expected) {
+  var result;
+  try {
+    result = eval(expression);
+  }
+  catch (e) {
+    e.message = "Error in " + expression + " in " + library + ": " + e.message;
+    throw e;
+  }
+  chai.expect(result).to.eql(expected, "unexpected " + library + " result");
+}


### PR DESCRIPTION
Not safe to merge. This demonstrates how jquery and vdom-query-rewrite are already different, e.g.

``` JavaScript
var $ = require('jquery');

$('<a />').find('a').length;
=> 0
```

``` JavaScript
var h = require('virtual-dom/h');
var $ = require('vdom-query');

$(h('a')).find('a').length;
=> 1
```

@dereke, what do you reckon we should do?
